### PR TITLE
ISSUE-90: Better handling of synchronous (sequential) requests

### DIFF
--- a/src/lib/components/ng-http-loader.component.ts
+++ b/src/lib/components/ng-http-loader.component.ts
@@ -24,6 +24,7 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
     public spinkit = Spinkit;
     private subscriptions: Subscription;
     private startTime: number;
+    private extraDurationTimer: number;
 
     @Input()
     public backgroundColor: string;
@@ -39,6 +40,8 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
     public debounceDelay = 0;
     @Input()
     public minDuration = 0;
+    @Input()
+    public extraDuration = 0;
     @Input()
     public entryComponent: any = null;
 
@@ -101,7 +104,18 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
     }
 
     private handleSpinnerVisibility(hasPendingRequests: boolean): void {
-        this.isSpinnerVisible = hasPendingRequests;
+        if (hasPendingRequests) {
+            if (this.extraDurationTimer) {
+                clearTimeout(this.extraDurationTimer);
+            }
+            this.isSpinnerVisible = true;
+        } else {
+            if (this.extraDuration) {
+                this.extraDurationTimer = setTimeout(() => this.isSpinnerVisible = false, this.extraDuration);
+            } else {
+                this.isSpinnerVisible = false;
+            }
+        }
     }
 
     private handleDebounceDelay(hasPendingRequests: boolean): Observable<number | never> {

--- a/src/test/components/ng-http-loader.component.spec.ts
+++ b/src/test/components/ng-http-loader.component.spec.ts
@@ -532,6 +532,40 @@ describe('NgHttpLoaderComponent', () => {
         }
     )));
 
+    it('should handle the extra spinner duration for multiple HTTP requests ran one after the others', fakeAsync(inject(
+        [HttpClient, HttpTestingController], (http: HttpClient, httpMock: HttpTestingController) => {
+            component.extraDuration = 10;
+
+            function runQuery(url: string): Observable<any> {
+                return http.get(url);
+            }
+
+            runQuery('/fake').subscribe();
+            const firstRequest = httpMock.expectOne('/fake');
+
+            tick(1000);
+            expect(component.isSpinnerVisible).toBeTruthy();
+
+            // the first HTTP request is finally over, the spinner is still visible for at least 10ms
+            firstRequest.flush({});
+            tick(5);
+            expect(component.isSpinnerVisible).toBeTruthy();
+
+            // But 5 ms after the first HTTP request has finished, a second HTTP request has been launched
+            runQuery('/fake2').subscribe();
+            const secondRequest = httpMock.expectOne('/fake2');
+
+            // After 700ms, the second http request ends. The spinner is still visible
+            tick(700);
+            secondRequest.flush({});
+            expect(component.isSpinnerVisible).toBeTruthy();
+
+            // 10ms later, the spinner should be  hidden (extraDuration)
+            tick(10);
+            expect(component.isSpinnerVisible).toBeFalsy();
+        }
+    )));
+
     it('should still display the spinner when the minimum duration is inferior to the HTTP request duration', fakeAsync(inject(
         [HttpClient, HttpTestingController], (http: HttpClient, httpMock: HttpTestingController) => {
             component.minDuration = 1000;


### PR DESCRIPTION
* added support for `extraDuration` feature
* added test for `extraDuration` feature
* `extraDuration` should delay spinner hiding at specified time (in millis), this should help to avoid spinner blinking on sequential requests (when crafting of one request depends on data from previous request, so that between those request may arrive ~5ms gap)

Although this implementation doesn't use any of rxjs features, it's advantage is that it is quite simple, I think.