### PR TITLE
ISSUE-90: Better handling of synchronous (sequential) requests

### DIFF
--- a/src/lib/components/ng-http-loader.component.ts
+++ b/src/lib/components/ng-http-loader.component.ts
@@ -23,7 +23,7 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
     public isSpinnerVisible: boolean;
     public spinkit = Spinkit;
     private subscriptions: Subscription;
-    private startTime: number;
+    private visibleUntil: number = Date.now();
 
     @Input()
     public backgroundColor: string;
@@ -106,19 +106,15 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
         this.pendingInterceptorService.filteredHeaders = this.filteredHeaders;
     }
 
-    private handleSpinnerVisibility(hasPendingRequests: boolean): void {
-        if (hasPendingRequests) {
-            this.startTime = Date.now();
+    private handleSpinnerVisibility(showSpinner: boolean): void {
+        const now = Date.now();
+        if (showSpinner && this.visibleUntil < now) {
+            this.visibleUntil = now + this.minDuration;
         }
-        this.isSpinnerVisible = hasPendingRequests;
+        this.isSpinnerVisible = showSpinner;
     }
-
-    private getSpinnerVisibilityDuration(): number {
-        return Date.now() - this.startTime;
-    }
-
 
     private getHiddingTimer(): Observable<number> {
-        return timer(Math.max(this.extraDuration, this.minDuration - this.getSpinnerVisibilityDuration()));
+        return timer(Math.max(this.extraDuration, this.visibleUntil - Date.now()));
     }
 }

--- a/src/lib/components/ng-http-loader.component.ts
+++ b/src/lib/components/ng-http-loader.component.ts
@@ -76,13 +76,13 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
         }
     }
 
-    private initFilters() {
+    private initFilters(): void {
         this.initFilteredUrlPatterns();
         this.initFilteredMethods();
         this.initFilteredHeaders();
     }
 
-    private initFilteredUrlPatterns() {
+    private initFilteredUrlPatterns(): void {
         if (!(this.filteredUrlPatterns instanceof Array)) {
             throw new TypeError('`filteredUrlPatterns` must be an array.');
         }
@@ -94,14 +94,14 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
         }
     }
 
-    private initFilteredMethods() {
+    private initFilteredMethods(): void {
         if (!(this.filteredMethods instanceof Array)) {
             throw new TypeError('`filteredMethods` must be an array.');
         }
         this.pendingInterceptorService.filteredMethods = this.filteredMethods;
     }
 
-    private initFilteredHeaders() {
+    private initFilteredHeaders(): void {
         if (!(this.filteredHeaders instanceof Array)) {
             throw new TypeError('`filteredHeaders` must be an array.');
         }

--- a/src/lib/components/ng-http-loader.component.ts
+++ b/src/lib/components/ng-http-loader.component.ts
@@ -107,7 +107,7 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
 
     private handleSpinnerVisibility(showSpinner: boolean): void {
         const now = Date.now();
-        if (showSpinner && this.visibleUntil < now) {
+        if (showSpinner && this.visibleUntil <= now) {
             this.visibleUntil = now + this.minDuration;
         }
         this.isSpinnerVisible = showSpinner;

--- a/src/lib/components/ng-http-loader.component.ts
+++ b/src/lib/components/ng-http-loader.component.ts
@@ -47,6 +47,7 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
     constructor(private pendingInterceptorService: PendingInterceptorService, private spinnerVisibilityService: SpinnerVisibilityService) {
         const showSpinner = this.pendingInterceptorService.pendingRequestsStatus$.pipe(filter(it => it));
         const hideSpinner = this.pendingInterceptorService.pendingRequestsStatus$.pipe(filter(it => !it));
+
         this.subscriptions = merge(
             showSpinner.pipe(debounce(() => timer(this.debounceDelay))),
             showSpinner.pipe(
@@ -55,7 +56,9 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
                 ))
             ),
             this.spinnerVisibilityService.visibilityObservable$,
-        ).pipe(distinctUntilChanged()).subscribe(status => this.handleSpinnerVisibility(status));
+        )
+            .pipe(distinctUntilChanged())
+            .subscribe(status => this.handleSpinnerVisibility(status));
     }
 
     ngOnInit(): void {

--- a/src/test/components/ng-http-loader.component.spec.ts
+++ b/src/test/components/ng-http-loader.component.spec.ts
@@ -518,15 +518,16 @@ describe('NgHttpLoaderComponent', () => {
             const secondRequest = httpMock.expectOne('/fake2');
             expect(component.isSpinnerVisible).toBeTruthy();
 
-            // After 900ms, the second http request ends. The spinner should
+            // After 900ms, the spinner should
             // still be visible because the second HTTP request is still pending
             tick(900);
             expect(component.isSpinnerVisible).toBeTruthy();
 
             // 500 ms later, the second http request ends. The spinner should be hidden
-            // Total time spent visible (1000+200+900+500==2600 > minDuration)
+            // Total time spent visible (1000+200+1400==2600 > minDuration)
             tick(500);
             secondRequest.flush({});
+            tick();
             expect(component.isSpinnerVisible).toBeFalsy();
         }
     )));


### PR DESCRIPTION
* added support for `extraDuration` feature
* added test for `extraDuration` feature
* `extraDuration` should delay spinner hiding at specified time (in millis), this should help to avoid spinner blinking on sequential requests (when crafting of one request depends on data from previous request, so that between those request may arrive ~5ms gap)