### PR TITLE
Remove unnecessary code

### DIFF
--- a/src/lib/components/ng-http-loader.component.ts
+++ b/src/lib/components/ng-http-loader.component.ts
@@ -112,9 +112,8 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
     }
 
     private handleSpinnerVisibility(showSpinner: boolean): void {
-        const now = Date.now();
-        if (showSpinner && this.visibleUntil <= now) {
-            this.visibleUntil = now + this.minDuration;
+        if (showSpinner) {
+            this.visibleUntil = Date.now() + this.minDuration;
         }
         this.isSpinnerVisible = showSpinner;
     }


### PR DESCRIPTION
* due to `distinctUntilChanged` we will get only one show/hide (true/false) event in `handleSpinnerVisibility` method.