### PR TITLE
Fix an error when destroying the component

### DIFF
--- a/src/lib/components/ng-http-loader.component.ts
+++ b/src/lib/components/ng-http-loader.component.ts
@@ -45,12 +45,12 @@ export class NgHttpLoaderComponent implements OnDestroy, OnInit {
     public entryComponent: any = null;
 
     constructor(private pendingInterceptorService: PendingInterceptorService, private spinnerVisibilityService: SpinnerVisibilityService) {
+        this.initializeSubscription();
     }
 
     ngOnInit(): void {
         this.nullifySpinnerIfEntryComponentIsDefined();
         this.initFilters();
-        this.initializeSubscription();
     }
 
     ngOnDestroy(): void {

--- a/src/test/components/ng-http-loader.component.spec.ts
+++ b/src/test/components/ng-http-loader.component.spec.ts
@@ -16,6 +16,13 @@ import { NgHttpLoaderComponent } from '../../lib/components/ng-http-loader.compo
 import { PendingInterceptorServiceInterceptor } from '../../lib/services/pending-interceptor.service';
 import { SpinnerVisibilityService } from '../../lib/services/spinner-visibility.service';
 import { Spinkit, SPINKIT_COMPONENTS } from '../../lib/spinkits';
+import { Component } from '@angular/core';
+
+@Component({
+    template: '<ng-http-loader id="http-loader"></ng-http-loader>'
+})
+export class ComponentWithLoaderComponent {
+}
 
 describe('NgHttpLoaderComponent', () => {
     let component: NgHttpLoaderComponent;
@@ -23,7 +30,7 @@ describe('NgHttpLoaderComponent', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [NgHttpLoaderComponent, ...SPINKIT_COMPONENTS],
+            declarations: [NgHttpLoaderComponent, ComponentWithLoaderComponent, ...SPINKIT_COMPONENTS],
             imports: [HttpClientTestingModule],
             providers: [PendingInterceptorServiceInterceptor]
         })
@@ -33,7 +40,6 @@ describe('NgHttpLoaderComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(NgHttpLoaderComponent);
         component = fixture.componentInstance;
-        component.ngOnInit();
     });
 
     it('should create the ng-http-loader component', () => {
@@ -50,6 +56,19 @@ describe('NgHttpLoaderComponent', () => {
             .nativeElement;
 
         expect(element.className).toBe('sk-cube-grid colored');
+    });
+
+    it('should destroy ng-http-loader as a view dependency without error', () => {
+        const fixtureWithLoader = TestBed.createComponent(ComponentWithLoaderComponent);
+        const componentWithLoader = fixtureWithLoader.componentInstance;
+        expect(componentWithLoader).toBeTruthy();
+
+        const element = fixtureWithLoader
+            .debugElement
+            .query(By.css('#http-loader'));
+        expect(element).toBeTruthy();
+
+        // There shouldn't be any errors in the console when the testbed cleans up the component.
     });
 
     it('should not set the colored class if background-color is defined', () => {
@@ -282,7 +301,6 @@ describe('NgHttpLoaderComponent', () => {
 
             const newFixture = TestBed.createComponent(NgHttpLoaderComponent);
             const newComponent = newFixture.componentInstance;
-            newComponent.ngOnInit();
 
             tick();
             expect(newComponent.isSpinnerVisible).toBeTruthy();


### PR DESCRIPTION
When I'm using `ng-http-loader` in my unit tests, I'm having the following error when the TestBed cleans after itself

```
ERROR: 'Error during cleanup of component', Object{component: AppComponent{}, stacktrace: TypeError: Cannot read property 'unsubscribe' of undefined
TypeError: Cannot read property 'unsubscribe' of undefined
    at NgHttpLoaderComponent.ngOnDestroy (./node_modules/ng-http-loader/fesm5/ng-http-loader.js?:491:28)
    at callProviderLifecycles (./node_modules/@angular/core/fesm5/core.js?:9864:18)
    at callElementProvidersLifecycles (./node_modules/@angular/core/fesm5/core.js?:9832:13)
    at callLifecycleHooksChildrenFirst (./node_modules/@angular/core/fesm5/core.js?:9822:29)
    at destroyView (./node_modules/@angular/core/fesm5/core.js?:10884:5)
    at callViewAction (./node_modules/@angular/core/fesm5/core.js?:11010:13)
    at execComponentViewsAction (./node_modules/@angular/core/fesm5/core.js?:10932:13)
    at destroyView (./node_modules/@angular/core/fesm5/core.js?:10883:5)
    at callWithDebugContext (./node_modules/@angular/core/fesm5/core.js?:11642:25)
```